### PR TITLE
Two clock speed common

### DIFF
--- a/Common/mercury18.h
+++ b/Common/mercury18.h
@@ -57,10 +57,16 @@
  * The following constants are defined presuming that BRGH=1 and BRG16=0, and
  * that the PLL is active.
  */
-
+#if 1
+/* For Fosc = 32000000 */
+#define BAUD_115200 16
+#define BAUD_38400 51
+#define BAUD_19200 103
+#else
+/* For Fosc = 64000000 */
 #define BAUD_115200 34
 #define BAUD_38400 103
 #define BAUD_19200 207
-
+#endif
 
 #endif	// MERCURY18_H

--- a/Common/mercury18.h
+++ b/Common/mercury18.h
@@ -57,6 +57,11 @@
  * The following constants are defined presuming that BRGH=1 and BRG16=0, and
  * that the PLL is active.
  */
+
+/* The first batch of Mercury 18s were built with an 8 MHz resonator instead of 
+ * a 16 MHz one.  The following #if #else allows you to set which speed you 
+ * have.
+ */
 #if 1
 /* For Fosc = 32000000 */
 #define BAUD_115200 16


### PR DESCRIPTION
This fork adds an explanation of why your Mercury 18 will have one of two clock speeds.  With a precompiler if-else, the user can select their speed.  The change affects the generated BAUD rate.
